### PR TITLE
Fix read json

### DIFF
--- a/src/shell_file_system.cpp
+++ b/src/shell_file_system.cpp
@@ -88,6 +88,11 @@ void ShellFileSystem::Reset(FileHandle &handle) {
 
 int64_t ShellFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	FILE *pipe = handle.Cast<ShellFileHandle>().pipe;
+
+	if (!pipe) {
+		return 0;
+	}
+
 	int64_t bytes_read = fread(buffer, 1, nr_bytes, pipe);
 	if (bytes_read == -1)
 	{

--- a/test/sql/json.test
+++ b/test/sql/json.test
@@ -1,0 +1,13 @@
+# name: test/sql/json.test
+# description: test shellfs extension
+# group: [shellfs]
+
+# Require statement will ensure this test is run with this extension loaded
+require shellfs
+
+require json
+
+query I
+SELECT count(*) FROM (DESCRIBE select * from read_json('curl -s http://worldtimeapi.org/api/timezone/Etc/UTC  |'));
+----
+15


### PR DESCRIPTION
Test case that this fixes is:
```sql
select * from read_json('curl -s http://worldtimeapi.org/api/timezone/Etc/UTC |');
```

that would otherwise segfault when pipe is read when already closed.